### PR TITLE
[INFRA] Update Sanitizer CI

### DIFF
--- a/.github/workflows/cron_sanitizer.yml
+++ b/.github/workflows/cron_sanitizer.yml
@@ -41,22 +41,19 @@ jobs:
 
         include:
           - name: "ASan"
+            os: macos-latest
             cxx_flags: "-fno-omit-frame-pointer -fsanitize=address"
 
+          - name: "ASan"
+            os: ubuntu-latest
+            cxx_flags: "-fno-omit-frame-pointer -Wno-maybe-unitialized -fsanitize=address"
+            
           - name: "TSan"
             cxx_flags: "-fno-omit-frame-pointer -fsanitize=thread"
 
           - name: "UBSan"
             os: macos-latest
-            cxx_flags: "-fno-omit-frame-pointer -fsanitize=undefined,float-divide-by-zero,implicit-conversion,local-bounds,nullability -Wno-pass-failed"
-
-          - name: "UBSan"
-            os: macos-latest
-            build_type: Release
-
-          - name: "UBSan"
-            os: macos-latest
-            build_type: RelWithDebInfo
+            cxx_flags: "-fno-omit-frame-pointer -fsanitize=undefined,float-divide-by-zero,local-bounds,nullability"
 
           - name: "UBSan"
             os: ubuntu-latest


### PR DESCRIPTION
* Add `-Wno-maybe-unitialized` to gcc (bogus warnings)
* Do not check for implicit conversions in UBSan (seqan2 does a lot of implicit conversions from unsigned to signed int and vice versa)